### PR TITLE
adopt some node best practices

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -1,5 +1,9 @@
 Minimal container image for running NodeJS apps
 
+The image specifies a default non-root `node` user (UID 65532), and a working directory at `/app`, owned by that `node` user, and accessible to all users.
+
+It specifies `NODE_PORT=3000` by default.
+
 ### Example
 
 Navigate to the `example/` directory:

--- a/apko.yaml
+++ b/apko.yaml
@@ -16,7 +16,7 @@ paths:
     type: directory
     permissions: 0o777
     uid: 65532
-    gid: 66632
+    gid: 66532
 
 work-dir: /app
 

--- a/apko.yaml
+++ b/apko.yaml
@@ -16,7 +16,7 @@ paths:
     type: directory
     permissions: 0o777
     uid: 65532
-    gid: 66532
+    gid: 65532
 
 work-dir: /app
 

--- a/apko.yaml
+++ b/apko.yaml
@@ -9,19 +9,37 @@ contents:
     - nghttp2
     - nodejs
 
+# By convention, Node apps run in an /app directory, which should be owned by
+# the non-root node user.
 paths:
-  - path: /work
+  - path: /app
     type: directory
     permissions: 0o777
+    uid: 65532
+    gid: 66632
 
-work-dir: /work
+work-dir: /app
 
 environment:
+  # By convention, Node apps look to the NODE_PORT env var to determine what
+  # port to listen on. Default to a high port since the user runs as non-root.
+  NODE_PORT: 3000
   PATH: /usr/sbin:/sbin:/usr/bin:/bin
 
 entrypoint:
   command: /usr/bin/node
 cmd: --help
+
+# By convention, the official Docker node image defines a `node` user, but
+# doesn't run as it unless the image based on it specifies that user.
+accounts:
+  groups:
+    - groupname: node
+      gid: 65532
+  users:
+    - username: node
+      uid: 65532
+  run-as: 65532
 
 archs:
 - x86_64

--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -4,12 +4,10 @@
 FROM cgr.dev/chainguard/node
 ENV NODE_ENV=production
 
-WORKDIR /app
-
-COPY ["package.json", "package-lock.json*", "./"]
+COPY --chown=node:node ["package.json", "package-lock.json*", "./"]
 
 RUN npm install --production
 
-COPY . .
+COPY --chown=node:node . .
 
 CMD [ "server.js" ]


### PR DESCRIPTION
Based on talking with @bretfisher and reading through guidance in https://github.com/BretFisher/nodejs-rocks-in-docker

- create and use a non-root user named `node` by default (the `node:latest` image creates this user, but doesn't use it by default)
- create and use `/app` as the workdir, owned by the `node` user
- set the `NODE_PORT` env var to 3000 by convention

Despite creating `/app` as owned by the `node` user, we still seem to need to `COPY` with `--chown=node:node` -- it'd be great to figure out how to avoid that. 🤔 

Now that our image is starting to diverge from Docker's `node` image, I should also write a doc in this repo about the differences, and what you can remove from your Dockerfile if you migrate.

Signed-off-by: Jason Hall <jason@chainguard.dev>