### PR TITLE
Add arm64 architecture to node image

### DIFF
--- a/.github/workflows/pre-submit.yaml
+++ b/.github/workflows/pre-submit.yaml
@@ -28,6 +28,7 @@ jobs:
       with:
         config: apko.yaml
         tag: node:${{ steps.snapshot-date.outputs.date }}
+        archs: x86_64,aarch64
 
     - uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,6 +43,7 @@ jobs:
         config: apko.yaml
         image_refs: apko.images
         base-tag: ghcr.io/${{ github.repository }}
+        archs: x86_64,aarch64
 
     - name: Emit Image Refs output
       id: emit-refs

--- a/apko.yaml
+++ b/apko.yaml
@@ -43,3 +43,4 @@ accounts:
 
 archs:
 - x86_64
+- aarch64


### PR DESCRIPTION
Closes chainguard-images/images#95 

Adding arm64 (`aarch64`) architecture to node image build. 

I tried to follow the changes in https://github.com/chainguard-images/nginx/pull/1